### PR TITLE
py3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
     - TOX_ENV=py27-django1.7-drf3.1
     - TOX_ENV=py27-django1.8-drf3.0
     - TOX_ENV=py27-django1.8-drf3.1
+    - TOX_ENV=py34-django1.7-drf3.0
+    - TOX_ENV=py34-django1.7-drf3.1
+    - TOX_ENV=py34-django1.8-drf3.0
+    - TOX_ENV=py34-django1.8-drf3.1
 
 matrix:
   fast_finish: true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
        py27-{flake8,docs},
-       py27-django{1.7,1.8}-drf{3.0,3.1}
+       py{27,34}-django{1.7,1.8}-drf{3.0,3.1}
+
 
 [testenv]
 commands = ./runtests.py --fast


### PR DESCRIPTION
This PR add py3 test environments so that py3 support is ensured.

The 2to3 tools did not asked for useful changes.

