### PR TITLE
Get serializer_class with view.get_serializer_class()

### DIFF
--- a/dry_rest_permissions/generics.py
+++ b/dry_rest_permissions/generics.py
@@ -100,9 +100,9 @@ class DRYPermissions(permissions.BasePermission):
         """
         if not self.global_permissions:
             return True
-            
+
         serializer_class = view.get_serializer_class()
-        
+
         assert serializer_class.Meta.model is not None, (
             "global_permissions set to true without a model "
             "set on the serializer for '%s'" % view.__class__.__name__
@@ -133,7 +133,7 @@ class DRYPermissions(permissions.BasePermission):
         """
         if not self.object_permissions:
             return True
-        
+
         serializer_class = view.get_serializer_class()
         model_class = serializer_class.Meta.model
         action_method_name = None

--- a/dry_rest_permissions/generics.py
+++ b/dry_rest_permissions/generics.py
@@ -100,13 +100,15 @@ class DRYPermissions(permissions.BasePermission):
         """
         if not self.global_permissions:
             return True
-
-        assert view.serializer_class.Meta.model is not None, (
+            
+        serializer_class = view.get_serializer_class()
+        
+        assert serializer_class.Meta.model is not None, (
             "global_permissions set to true without a model "
             "set on the serializer for '%s'" % view.__class__.__name__
         )
 
-        model_class = view.serializer_class.Meta.model
+        model_class = serializer_class.Meta.model
 
         action_method_name = None
         if hasattr(view, 'action'):
@@ -131,8 +133,9 @@ class DRYPermissions(permissions.BasePermission):
         """
         if not self.object_permissions:
             return True
-
-        model_class = view.serializer_class.Meta.model
+        
+        serializer_class = view.get_serializer_class()
+        model_class = serializer_class.Meta.model
         action_method_name = None
         if hasattr(view, 'action'):
             action = self._get_action(view.action)


### PR DESCRIPTION
Hello, 

I have this error when I want to use your package with my users : 
```
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/viewsets.py", line 87, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 466, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 454, in dispatch
    self.initial(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 377, in initial
    self.check_permissions(request)
  File "/usr/local/lib/python2.7/site-packages/rest_framework/views.py", line 318, in check_permissions
    if not permission.has_permission(request, self):
  File "/usr/local/lib/python2.7/site-packages/dry_rest_permissions/generics.py", line 104, in has_permission
    assert view.serializer_class.Meta.model is not None, (
AttributeError: 'NoneType' object has no attribute 'Meta'
```

In fact, I use two serializers for my user views and I do not use the serializer_class attribute : 
```python
class UserViews(ModelViewSet, AbstractBaseViews):
    queryset = User.objects.all()
    permission_classes = (DRYPermissions,)

    def get_serializer_class(self):
        if self.request.method == 'POST':
            return RegisterSerializer
        return UserSerializer
```

That's why I think we should use the get serializer class method rather than the attribute serializer_class.